### PR TITLE
Add link to docs in output report

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -128,6 +128,7 @@ runs:
         uv run cite-runner \
             parse-result \
             --output-format=markdown \
+            --exit-without-error \
             --with-summary \
             ${{ fromJSON(inputs.with_failed) && '--with-failed \' || '--without-failed \'}}
             ${{ fromJSON(inputs.with_skipped) && '--with-skipped \' || '--without-skipped \'}}

--- a/action.yml
+++ b/action.yml
@@ -32,21 +32,21 @@ inputs:
     required: false
     default: "120"
     description: Timeout value for network requests
-  include_failed_test_details:
+  with_failed:
     required: false
-    default: "true"
+    default: "false"
     description: Whether the output report should include information about failed tests
-  include_skipped_test_details:
+  with_skipped:
     required: false
-    default: "true"
+    default: "false"
     description: Whether the output report should include information about skipped tests
-  include_passed_test_details:
+  with_passed:
     required: false
     default: "false"
     description: Whether the output report should include information about passed tests
-  exit_with_error_on_suite_failed_result:
+  exit_with_error:
     required: false
-    default: "false"
+    default: "true"
     description: Whether the action exits with an error if the test suite execution shows a result of failed.
 
 outputs:
@@ -109,12 +109,12 @@ runs:
         echo "::group::Suite execution results"
         uv run cite-runner \
             parse-result \
-            ${{ fromJSON(inputs.exit_with_error_on_suite_failed_result) && '--exit-with-error-on-suite-failed-result \' || '--no-exit-with-error-on-suite-failed-result \'}}
+            ${{ fromJSON(inputs.exit_with_error) && '--exit-with-error \' || '--exit-without-error \'}}
             --output-format=console \
-            --include-summary \
-            --include-failed-detail \
-            --include-skipped-detail \
-            --include-passed-detail \
+            --with-summary \
+            --with-failed \
+            --with-skipped \
+            --with-passed \
             ${{ steps.run_executable_test_suite.outputs.RAW_RESULT_OUTPUT_PATH }}
         echo "CITE_RUNNER_EXIT_CODE=$?" >> "${GITHUB_OUTPUT}"
         echo "::endgroup::"
@@ -128,10 +128,10 @@ runs:
         uv run cite-runner \
             parse-result \
             --output-format=markdown \
-            --include-summary \
-            ${{ fromJSON(inputs.include_failed_test_details) && '--include-failed-detail \' || '--no-include-failed-detail \'}}
-            ${{ fromJSON(inputs.include_skipped_test_details) && '--include-skipped-detail \' || '--no-include-skipped-detail \'}}
-            ${{ fromJSON(inputs.include_passed_test_details) && '--include-passed-detail \' || '--no-include-passed-detail \'}}
+            --with-summary \
+            ${{ fromJSON(inputs.with_failed) && '--with-failed \' || '--without-failed \'}}
+            ${{ fromJSON(inputs.with_skipped) && '--with-skipped \' || '--without-skipped \'}}
+            ${{ fromJSON(inputs.with_passed) && '--with-passed \' || '--without-passed \'}}
             ${{ steps.run_executable_test_suite.outputs.RAW_RESULT_OUTPUT_PATH }} 1> ${md_result_output_path}
         echo "MARKDOWN_RESULT_OUTPUT_PATH=${{ github.action_path }}/${md_result_output_path}" >> "${GITHUB_OUTPUT}"
     - name: 'store execution results as artifacts'

--- a/docs/running-as-github-action.md
+++ b/docs/running-as-github-action.md
@@ -3,25 +3,25 @@ hide:
   - navigation
 ---
 
-# Running as a github action
+# Running as a GitHub action
 
 ![github-action-runner](assets/github-action-demo.png)
 
 ## Overview
 
-In order to run cite-runner as a [github action], include it in your workflow
+In order to run cite-runner as a [GitHub action], include it in your workflow
 and specify which test suite to run, alongside any relevant parameters.
 
 
 !!! tip
 
-    Although cite-runner is not yet published in the [github marketplace] it
-    can still be used in github CI workflows.
+    Although cite-runner is not yet published in the [GitHub marketplace] it
+    can still be used in GitHub CI workflows.
 
-[github action]: https://docs.github.com/en/actions/sharing-automations/creating-actions/about-custom-actions
-[github marketplace]: https://github.com/marketplace
+[GitHub action]: https://docs.github.com/en/actions/sharing-automations/creating-actions/about-custom-actions
+[GitHub marketplace]: https://github.com/marketplace
 
-Include it as any other github action, by creating a workflow step that
+Include it as any other GitHub action, by creating a workflow step that
 specifies `uses: OSGEO/cite-runner` and provide execution parameters in the
 `with` parameter.
 
@@ -32,18 +32,19 @@ jobs:
   perform-cite-testing:
     runs-on: ubuntu-24.04
     steps:
+
+      # other steps which start your OGC implementation and wait for it to become available
+
       - name: test ogcapi-features compliancy
         uses: OSGEO/cite-runner@main
         with:
           test_suite_identifier: ogcapi-features-1.0
-          test_session_arguments: >-
-            iut=http://localhost:5001
-            noofcollections=-1
+          test_session_arguments: iut=http://localhost:5001
 ```
 
 ## Inputs
 
-When run as a github action, cite-runner expects the following inputs to be provided:
+When run as a GitHub action, cite-runner expects the following inputs to be provided:
 
 
 ### `test_suite_identfier`
@@ -132,60 +133,76 @@ When run as a github action, cite-runner expects the following inputs to be prov
 - **Description**: Timeout value for network requests, in seconds
 
 
-### `include_failed_test_details`
+### `with_failed`
 
-- **Required**: No (defaults to `true`)
-- **Description**: Whether the output report should include information about failed tests
+- **Required**: No (defaults to `'false'`)
+- **Description**: Whether the output report should include information about failed tests.
+
+    Note that regardless of this input's value, the workflow execution logs always include the full test suite
+    execution details, which include any information related to failed tests.
 
 !!! note
 
-    This input is parsed into a boolean with the github actions [fromJSON() function] and is then evaluated
-    with github's [ternary operator]. This means that if you pass it a value of either `true` or `false`
-    everything will work as intended.
+    [GitHub actions inputs] are always interpreted as strings by default. However, this input is parsed into a
+    boolean with the GitHub actions [fromJSON() function] and is then evaluated with GitHub's [ternary operator].
+    This means that if you pass it a value of either `'true'` or `'false'` everything will work as intended.
 
 
-### `include_skipped_test_details`
 
-- **Required**: No (defaults to `true`)
+### `with_skipped`
+
+- **Required**: No (defaults to `false`)
 - **Description**: Whether the output report should include information about skipped tests
 
+    Note that regardless of this input's value, the workflow execution logs always include the full test suite
+    execution details, which include any information related to skipped tests.
+
 !!! note
 
-    This input is parsed into a boolean with the github actions [fromJSON() function] and is then evaluated
-    with github's [ternary operator]. This means that if you pass it a value of either `true` or `false`
-    everything will work as intended.
+    [GitHub actions inputs] are always interpreted as strings by default. However, this input is parsed into a
+    boolean with the GitHub actions [fromJSON() function] and is then evaluated with GitHub's [ternary operator].
+    This means that if you pass it a value of either `'true'` or `'false'` everything will work as intended.
 
 
-### `include_passed_test_details`
+
+### `with_passed`
 
 - **Required**: No (defaults to `false`)
 - **Description**: Whether the output report should include information about passed tests
 
+    Note that regardless of this input's value, the workflow execution logs always include the full test suite
+    execution details, which include any information related to passed tests.
+
 !!! note
 
-    This input is parsed into a boolean with the github actions [fromJSON() function] and is then evaluated
-    with github's [ternary operator]. This means that if you pass it a value of either `true` or `false`
-    everything will work as intended.
+    [GitHub actions inputs] are always interpreted as strings by default. However, this input is parsed into a
+    boolean with the GitHub actions [fromJSON() function] and is then evaluated with GitHub's [ternary operator].
+    This means that if you pass it a value of either `'true'` or `'false'` everything will work as intended.
 
 
-### `exit_with_error_on_suite_failed_result`
 
-- **Required**: No (defaults to `false`)
+### `exit_with_error`
+
+- **Required**: No (defaults to `true`)
 - **Description**: Whether the action should exit with an error when a suite is declared as failed.
 
 !!! note
 
-    This input is parsed into a boolean with the github actions [fromJSON() function] and is then evaluated
-    with github's [ternary operator]. This means that if you pass it a value of either `true` or `false`
-    everything will work as intended.
+    [GitHub actions inputs] are always interpreted as strings by default. However, this input is parsed into a
+    boolean with the GitHub actions [fromJSON() function] and is then evaluated with GitHub's [ternary operator].
+    This means that if you pass it a value of either `'true'` or `'false'` everything will work as intended.
 
 
+
+[GitHub actions inputs]: https://docs.github.com/en/actions/sharing-automations/creating-actions/metadata-syntax-for-github-actions#inputs
 [fromJSON() function]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#fromjson
 [ternary operator]: https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/evaluate-expressions-in-workflows-and-actions#operators
 
-## Usage
 
-The below examples define a GitHub workflow for testing pygeoapi.
+## Usage examples
+
+
+### Simple
 
 Simple usage, running the `ogcapi-features-1.0` test suite whenever there is a `push`:
 
@@ -198,27 +215,82 @@ jobs:
   perform-cite-testing:
     runs-on: ubuntu-22.04
     steps:
-      - name: grab code
-        uses: actions/checkout@v4
 
-      - name: start pygeoapi with suitable CITE data and config
-        run: >
-          docker compose -f tests/cite/compose.test-cite.yaml up --detach
-
-      - name: wait for pygeoapi to be usable
-        uses: raschmitt/wait-for-healthy-container@v1.0.1
-        with:
-          container-name: pygeoapi-cite-pygeoapi-1
-          timeout: 120
+      # other steps which start your OGC implementation and wait for it to become available
 
       - name: test ogcapi-features compliancy
         uses: OSGEO/cite-runner@main
         with:
           test_suite_identifier: 'ogcapi-features-1.0'
+          test_session_arguments: iut=http://localhost:5001
+```
+
+
+### Provide multiple test suite inputs
+
+In this example we test for compliance with the `ogcapi-tiles-1.0` test suite and provide multiple input parameters.
+In order to keep the GitHub workflow file easily readable, inputs are specified by using the YAML `>-` feature mentioned
+above, which allows putting them on individual lines.
+
+```yaml
+on:
+  push:
+
+jobs:
+
+  perform-cite-testing:
+    runs-on: ubuntu-22.04
+    steps:
+
+      # other steps which start your OGC implementation and wait for it to become available
+
+      - name: test ogcapi-features compliancy
+        uses: OSGEO/cite-runner@main
+        with:
+          test_suite_identifier: 'ogcapi-tiles-1.0'
           test_session_arguments: >-
             iut=http://localhost:5001
-            noofcollections=-1
+            tilematrixsetdefinitionuri=http://www.opengis.net/def/tilematrixset/OGC/1.0/WebMercatorQuad
+            urltemplatefortiles=http://localhost:5001/collections/lakes/tiles/WebMercatorQuad/{tileMatrix}/{tileRow}/{tileCol}?f=mvt
+            tilematrix=0
+            mintilerow=0
+            maxtilerow=1
+            mintilecol=0
+            maxtilecol=1
 ```
+
+
+### Customize report and exit status
+
+In this example we ask for inclusion of details on both failed and skipped tests in the generated Markdown report. We
+also tell cite-runner to not exit with an error in case the tests fail. This can be used for cases where you don't
+want CITE failures to be breaking your CI workflow.
+
+
+```yaml
+on:
+  push:
+
+jobs:
+
+  perform-cite-testing:
+    runs-on: ubuntu-22.04
+    steps:
+
+      # other steps which start your OGC implementation and wait for it to become available
+
+      - name: test ogcapi-features compliancy
+        uses: OSGEO/cite-runner@main
+        with:
+          test_suite_identifier: 'ogcapi-features-1.0'
+          test_session_arguments: iut=http://localhost:5001
+          with_failed: "true"
+          with_skipped: "true"
+          exit_with_error: "false"
+```
+
+
+### Test several suites in parallel
 
 A slightly more complex example, using a matrix to test both `ogcapi-features-1.0`
 and `ogcapi-processes-1.0` test suites in parallel:
@@ -227,13 +299,10 @@ and `ogcapi-processes-1.0` test suites in parallel:
 on:
   push:
 
-env:
-  COLUMNS: 120
-
-
 jobs:
 
   perform-cite-testing:
+    continue-on-error: true
     strategy:
       matrix:
         test-suite:
@@ -249,25 +318,7 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
 
-      - name: grab code
-        uses: actions/checkout@v4
-
-      - name: start pygeoapi with suitable CITE data and config
-        run: >
-          docker compose -f tests/cite/compose.test-cite.yaml up --detach
-
-      - name: wait for pygeoapi to be usable
-        uses: raschmitt/wait-for-healthy-container@v1.0.1
-        with:
-          container-name: pygeoapi-cite-pygeoapi-1
-          timeout: 120
-
-      - name: collect docker logs on failure
-        if: failure()
-        uses: jwalton/gh-docker-logs@v2.2.2
-        with:
-          images: ghcr.io/geopython/pygeoapi
-          tail: 500
+      # other steps which start your OGC implementation and wait for it to become available
 
       - name: test ogcapi-features compliancy
         uses: OSGEO/cite-runner@main
@@ -280,7 +331,7 @@ jobs:
 
 ## Results
 
-The cite-runner github action stores both:
+The cite-runner GitHub action stores both:
 
 - Raw suite results, as output directly by OGC TeamEngine. This is an XML file that uses a schema based on the
   W3C EARL format
@@ -289,7 +340,7 @@ The cite-runner github action stores both:
 These results are saved as [workflow artifacts] and are available for download for further processing.
 
 Additionally, cite-runner also adds the contents of the parsed Markdown file as the job summary, making them directly
-visible in the github workflow run overview page:
+visible in the GitHub workflow run overview page:
 
 ![github-workflow-job-sumary](assets/github-action-summary.png)
 

--- a/src/cite_runner/__main__.py
+++ b/src/cite_runner/__main__.py
@@ -1,0 +1,3 @@
+from .main import app
+
+app(prog_name="cite-runner")

--- a/src/cite_runner/config.py
+++ b/src/cite_runner/config.py
@@ -27,6 +27,7 @@ class CiteRunnerSettings(BaseSettings):
     # ogcapi_features_1_0_markdown_serializer: str = (
     #     "cite_runner.teamengine_runner.serialize_test_suite_result")
     simple_serializer_template: str = "test-suite-result.md"
+    docs_url: str = "https://osgeo.github.io/cite-runner/"
     disclaimer: str = (
         "cite-runner is not affiliated with the OGC. Having a CITE test suite be declared as passed by cite-runner "
         "does not mean the implementation under test is OGC certified nor does it mean that it is guaranteed to pass "

--- a/src/cite_runner/config.py
+++ b/src/cite_runner/config.py
@@ -27,6 +27,11 @@ class CiteRunnerSettings(BaseSettings):
     # ogcapi_features_1_0_markdown_serializer: str = (
     #     "cite_runner.teamengine_runner.serialize_test_suite_result")
     simple_serializer_template: str = "test-suite-result.md"
+    disclaimer: str = (
+        "cite-runner is not affiliated with the OGC. Having a CITE test suite be declared as passed by cite-runner "
+        "does not mean the implementation under test is OGC certified nor does it mean that it is guaranteed to pass "
+        "the official CITE certification program."
+    )
 
 
 class CiteRunnerContext(pydantic.BaseModel):

--- a/src/cite_runner/main.py
+++ b/src/cite_runner/main.py
@@ -21,11 +21,17 @@ logger = logging.getLogger(__name__)
 app = typer.Typer()
 
 
+_DEFAULT_OUTPUT_FORMAT = models.OutputFormat.CONSOLE
+_DEFAULT_EXIT_WITH_ERROR = True
+_DEFAULT_INCLUDE_SUMMARY = True
+_DEFAULT_INCLUDE_FAILED = False
+_DEFAULT_INCLUDE_SKIPPED = False
+_DEFAULT_INCLUDE_PASSED = False
+
+
 def _parse_pydantic_secret_str(value: str) -> pydantic.SecretStr:
     return pydantic.SecretStr(value)
 
-
-_DEFAULT_OUTPUT_FORMAT = models.OutputFormat.MARKDOWN
 
 _test_suite_identifier_argument = typing.Annotated[
     str, typer.Argument(help="Identifier of the test suite. Ex: ogcapi-features-1.0")
@@ -50,6 +56,70 @@ _teamengine_password_option = typing.Annotated[
         parser=_parse_pydantic_secret_str,
     ),
 ]
+_output_format_option = typing.Annotated[
+    models.OutputFormat,
+    typer.Option(help="Output format for the suite execution result report"),
+]
+_exit_with_error_option = typing.Annotated[
+    bool,
+    typer.Option(
+        "--exit-with-error/--exit-without-error",
+        "-e/-E",
+        help="Exit with an error code of 1 if the test suite has failed.",
+    ),
+]
+
+_include_summary_option = typing.Annotated[
+    bool,
+    typer.Option(
+        "--with-summary/--without-summary",
+        "-f/-F",
+        help=(
+            "Include report section with test execution summary. Note that this does "
+            "not apply to the RAW and JSON output formats, as these always "
+            "include the full test execution report."
+        ),
+    ),
+]
+
+_include_failed_option = typing.Annotated[
+    bool,
+    typer.Option(
+        "--with-failed/--without-failed",
+        "-f/-F",
+        help=(
+            "Include report section detailing failed tests. Note that this does not "
+            "apply to the RAW and JSON output formats, as these always include the "
+            "full test execution report."
+        ),
+    ),
+]
+
+_include_skipped_option = typing.Annotated[
+    bool,
+    typer.Option(
+        "--with-skipped/--without-skipped",
+        "-f/-F",
+        help=(
+            "Include report section detailing skipped tests. Note that this does not "
+            "apply to the RAW and JSON output formats, as these always include the "
+            "full test execution report."
+        ),
+    ),
+]
+
+_include_passed_option = typing.Annotated[
+    bool,
+    typer.Option(
+        "--with-passed/--without-passed",
+        "-f/-F",
+        help=(
+            "Include report section detailing passed tests. Note that this does not "
+            "apply to the RAW and JSON output formats, as these always include the "
+            "full test execution report."
+        ),
+    ),
+]
 
 
 @app.callback()
@@ -70,30 +140,34 @@ def parse_test_result(
     test_suite_result: typing.Annotated[
         Path,
         typer.Argument(
-            exists=True, file_okay=True, dir_okay=False, help="Suite execution result"
+            # exists=True,
+            # file_okay=True,
+            # dir_okay=False,
+            allow_dash=True,
+            help="Suite execution result",
         ),
     ],
-    output_format: models.OutputFormat = _DEFAULT_OUTPUT_FORMAT,
-    exit_with_error_on_suite_failed_result: bool = False,
-    include_summary: bool = True,
-    include_failed_detail: bool = True,
-    include_skipped_detail: bool = True,
-    include_passed_detail: bool = False,
+    output_format: _output_format_option = _DEFAULT_OUTPUT_FORMAT,
+    include_summary: _include_summary_option = _DEFAULT_INCLUDE_SUMMARY,
+    include_failed: _include_failed_option = _DEFAULT_INCLUDE_FAILED,
+    include_skipped: _include_skipped_option = _DEFAULT_INCLUDE_SKIPPED,
+    include_passed: _include_passed_option = _DEFAULT_INCLUDE_PASSED,
+    exit_with_error: _exit_with_error_option = _DEFAULT_EXIT_WITH_ERROR,
 ):
     context: config.CiteRunnerContext = ctx.obj
     context.status_console.print("Parsing test suite execution results...")
-    parsed = teamengine_runner.parse_test_suite_result(
-        test_suite_result.read_text(), context.settings
-    )
+    with click.open_file(test_suite_result) as fh:
+        raw_result = fh.read()
+    parsed = teamengine_runner.parse_test_suite_result(raw_result, context.settings)
     context.status_console.print(f"Serializing parsed results to {output_format}...")
     serialized = teamengine_runner.serialize_suite_result(
         parsed,
         output_format,
         serialization_details=models.SerializationDetails(
             include_summary=include_summary,
-            include_failed_detail=include_failed_detail,
-            include_skipped_detail=include_skipped_detail,
-            include_passed_detail=include_passed_detail,
+            include_failed_detail=include_failed,
+            include_skipped_detail=include_skipped,
+            include_passed_detail=include_passed,
         ),
         context=ctx.obj,
     )
@@ -101,7 +175,7 @@ def parse_test_result(
         context.result_console.print(serialized)
     else:
         stdlib_print(serialized)
-    raise typer.Exit(_get_exit_code(parsed, exit_with_error_on_suite_failed_result))
+    raise typer.Exit(_get_exit_code(parsed, exit_with_error))
 
 
 @app.command()
@@ -109,7 +183,7 @@ def execute_test_suite_from_github_actions(
     ctx: typer.Context,
     teamengine_base_url: _teamengine_base_url_argument,
     test_suite_identifier: _test_suite_identifier_argument,
-    test_suite_input: typing.Annotated[
+    suite_input: typing.Annotated[
         list[str],
         typer.Argument(
             help=(
@@ -121,12 +195,12 @@ def execute_test_suite_from_github_actions(
     ],
     teamengine_username: _teamengine_username_option = "ogctest",
     teamengine_password: _teamengine_password_option = "ogctest",
-    exit_with_error_on_suite_failed_result: bool = False,
-    output_format: models.OutputFormat = _DEFAULT_OUTPUT_FORMAT,
-    include_summary: bool = True,
-    include_failed_detail: bool = True,
-    include_skipped_detail: bool = True,
-    include_passed_detail: bool = False,
+    output_format: _output_format_option = _DEFAULT_OUTPUT_FORMAT,
+    include_summary: _include_summary_option = _DEFAULT_INCLUDE_SUMMARY,
+    include_failed: _include_failed_option = _DEFAULT_INCLUDE_FAILED,
+    include_skipped: _include_skipped_option = _DEFAULT_INCLUDE_SKIPPED,
+    include_passed: _include_passed_option = _DEFAULT_INCLUDE_PASSED,
+    exit_with_error: _exit_with_error_option = _DEFAULT_EXIT_WITH_ERROR,
 ):
     """Execute a CITE test suite via github actions.
 
@@ -134,7 +208,7 @@ def execute_test_suite_from_github_actions(
     `execute-test-suite` command, making it easier to run as a github action.
     """
     suite_inputs = {}
-    for raw_suite_input in test_suite_input:
+    for raw_suite_input in suite_input:
         param_name, param_value = raw_suite_input.partition("=")[::2]
         param_values = suite_inputs.setdefault(param_name, [])
         param_values.append(param_value)
@@ -148,9 +222,9 @@ def execute_test_suite_from_github_actions(
         output_format=output_format,
         serialization_details=models.SerializationDetails(
             include_summary=include_summary,
-            include_failed_detail=include_failed_detail,
-            include_skipped_detail=include_skipped_detail,
-            include_passed_detail=include_passed_detail,
+            include_failed_detail=include_failed,
+            include_skipped_detail=include_skipped,
+            include_passed_detail=include_passed,
         ),
     )
     context: config.CiteRunnerContext = ctx.obj
@@ -161,7 +235,7 @@ def execute_test_suite_from_github_actions(
     raise typer.Exit(
         0
         if output_format == models.OutputFormat.RAW
-        else _get_exit_code(parsed, exit_with_error_on_suite_failed_result)
+        else _get_exit_code(parsed, exit_with_error)
     )
 
 
@@ -172,26 +246,26 @@ def execute_test_suite(
     test_suite_identifier: _test_suite_identifier_argument,
     teamengine_username: _teamengine_username_option = "ogctest",
     teamengine_password: _teamengine_password_option = "ogctest",
-    test_suite_input: typing.Annotated[
+    suite_input: typing.Annotated[
         typing.Optional[list[click.Tuple]],
         typer.Option(
             click_type=click.Tuple([str, str]),
             help=(
                 "Input name and value separated by a space. "
-                "Ex: --test-suite-input iut http://localhost:5000"
+                "Ex: --suite-input iut http://localhost:5000"
             ),
         ),
     ] = None,
-    output_format: models.OutputFormat = _DEFAULT_OUTPUT_FORMAT,
-    include_summary: bool = True,
-    include_failed_detail: bool = True,
-    include_skipped_detail: bool = True,
-    include_passed_detail: bool = False,
-    exit_with_error_on_suite_failed_result: bool = False,
+    output_format: _output_format_option = _DEFAULT_OUTPUT_FORMAT,
+    include_summary: _include_summary_option = _DEFAULT_INCLUDE_SUMMARY,
+    include_failed: _include_failed_option = _DEFAULT_INCLUDE_FAILED,
+    include_skipped: _include_skipped_option = _DEFAULT_INCLUDE_SKIPPED,
+    include_passed: _include_passed_option = _DEFAULT_INCLUDE_PASSED,
+    exit_with_error: _exit_with_error_option = _DEFAULT_EXIT_WITH_ERROR,
 ):
     """Execute a CITE test suite."""
     suite_inputs = {}
-    for param_name, param_value in test_suite_input:
+    for param_name, param_value in suite_input:
         param_values = suite_inputs.setdefault(param_name, [])
         param_values.append(param_value)
     context: config.CiteRunnerContext = ctx.obj
@@ -205,9 +279,9 @@ def execute_test_suite(
         output_format=output_format,
         serialization_details=models.SerializationDetails(
             include_summary=include_summary,
-            include_failed_detail=include_failed_detail,
-            include_skipped_detail=include_skipped_detail,
-            include_passed_detail=include_passed_detail,
+            include_failed_detail=include_failed,
+            include_skipped_detail=include_skipped,
+            include_passed_detail=include_passed,
         ),
     )
     if output_format == models.OutputFormat.RAW:
@@ -219,7 +293,7 @@ def execute_test_suite(
     raise typer.Exit(
         0
         if output_format == models.OutputFormat.RAW
-        else _get_exit_code(parsed, exit_with_error_on_suite_failed_result)
+        else _get_exit_code(parsed, exit_with_error)
     )
 
 

--- a/src/cite_runner/serializers/console.py
+++ b/src/cite_runner/serializers/console.py
@@ -1,5 +1,6 @@
 import humanize
 import rich.box
+from rich.padding import Padding
 from rich.panel import Panel
 from rich.table import Table
 from rich.console import (
@@ -29,7 +30,7 @@ def to_console(
         f"- 🟢 Passed {parsed_result.num_passed_tests} tests\n"
     )
     contents = [
-        Text(context.settings.disclaimer, style="bright_yellow"),
+        Padding(Text(context.settings.disclaimer, style="bright_yellow"), (0, 0, 1, 0)),
         overview_message,
     ]
     if serialization_details.include_summary:

--- a/src/cite_runner/serializers/console.py
+++ b/src/cite_runner/serializers/console.py
@@ -28,7 +28,10 @@ def to_console(
         f"- 🟡 Skipped {parsed_result.num_skipped_tests} tests\n"
         f"- 🟢 Passed {parsed_result.num_passed_tests} tests\n"
     )
-    contents = [overview_message]
+    contents = [
+        Text(context.settings.disclaimer, style="bright_yellow"),
+        overview_message,
+    ]
     if serialization_details.include_summary:
         summary_table = Table(title="Conformance classes", expand=True)
         summary_table.add_column("Class")

--- a/src/cite_runner/serializers/simple.py
+++ b/src/cite_runner/serializers/simple.py
@@ -1,3 +1,5 @@
+import json
+
 from .. import (
     config,
     models,
@@ -16,6 +18,7 @@ def to_markdown(
     return template.render(
         result=parsed_result,
         serialization_details=serialization_details,
+        disclaimer=context.settings.disclaimer,
     )
 
 
@@ -24,4 +27,8 @@ def to_json(
     serialization_details: models.SerializationDetails,
     context: config.CiteRunnerContext,
 ) -> str:
-    return parsed_result.model_dump_json(warnings="error")
+    serialized = parsed_result.model_dump_json(warnings="error")
+    reparsed = json.loads(serialized)
+    reparsed["disclaimer"] = context.settings.disclaimer
+    return json.dumps(reparsed)
+

--- a/src/cite_runner/serializers/simple.py
+++ b/src/cite_runner/serializers/simple.py
@@ -31,4 +31,3 @@ def to_json(
     reparsed = json.loads(serialized)
     reparsed["disclaimer"] = context.settings.disclaimer
     return json.dumps(reparsed)
-

--- a/src/cite_runner/serializers/simple.py
+++ b/src/cite_runner/serializers/simple.py
@@ -19,6 +19,7 @@ def to_markdown(
         result=parsed_result,
         serialization_details=serialization_details,
         disclaimer=context.settings.disclaimer,
+        docs_url=context.settings.docs_url,
     )
 
 
@@ -29,5 +30,8 @@ def to_json(
 ) -> str:
     serialized = parsed_result.model_dump_json(warnings="error")
     reparsed = json.loads(serialized)
-    reparsed["disclaimer"] = context.settings.disclaimer
+    reparsed["cite_runner"] = {
+        "disclaimer": context.settings.disclaimer,
+        "url": context.settings.docs_url,
+    }
     return json.dumps(reparsed)

--- a/src/cite_runner/templates/test-suite-result.md
+++ b/src/cite_runner/templates/test-suite-result.md
@@ -14,6 +14,8 @@
 - 🟡 Skipped {{ result.num_skipped_tests }} tests
 - 🟢 Passed {{ result.num_passed_tests }} tests
 
+ℹ️ - {{ disclaimer }}
+
 {%- if serialization_details.include_summary %}
 ##### Additional suite details
 

--- a/src/cite_runner/templates/test-suite-result.md
+++ b/src/cite_runner/templates/test-suite-result.md
@@ -1,5 +1,7 @@
 # Test suite {{ result.suite_title }} {% if result.passed %}🏅{% else %}❌{% endif %}
 
+<{{ docs_url }}>
+
 
 {%- if result.passed %}
 - **🏅 Test suite has passed!** - Teamengine reported that all core conformance classes have passed.
@@ -15,6 +17,7 @@
 - 🟢 Passed {{ result.num_passed_tests }} tests
 
 ℹ️ - {{ disclaimer }}
+
 
 {%- if serialization_details.include_summary %}
 ##### Additional suite details


### PR DESCRIPTION
This PR adds a link to cite-runner's docs in both the Markdown and JSON outputs.